### PR TITLE
 Increase the performance when restoring many selected rows

### DIFF
--- a/CS/RefreshHelperClass.cs
+++ b/CS/RefreshHelperClass.cs
@@ -217,6 +217,7 @@ namespace DevExpress.XtraGrid.Helpers {
             }
 
             public void LoadSelectionViewInfo(GridView view) {
+                view.DataController.EnsureFindRowByValueCache(view.DataController.Columns[descriptor.keyFieldName], view.RowCount);
                 view.BeginSelection();
                 try {
                     view.ClearSelection();
@@ -225,6 +226,7 @@ namespace DevExpress.XtraGrid.Helpers {
                 }
                 finally {
                     view.EndSelection();
+                    view.DataController.DestroyFindRowByValueCache();
                 }
             }
 

--- a/VB/RefreshHelperClass.vb
+++ b/VB/RefreshHelperClass.vb
@@ -237,19 +237,21 @@ Namespace DevExpress.XtraGrid.Helpers
 				view.TopRowIndex = view.GetVisibleIndex(view.FocusedRowHandle) - visibleRowIndex
 			End Sub
 
-			Public Sub LoadSelectionViewInfo(ByVal view As GridView)
-				view.BeginSelection()
-				Try
-					view.ClearSelection()
-					For i As Integer = 0 To SaveSelList.Count - 1
-						SelectRowByRowInfo(view, CType(SaveSelList(i), RowInfo), i = SaveSelList.Count - 1)
-					Next i
-				Finally
-					view.EndSelection()
-				End Try
-			End Sub
+            Public Sub LoadSelectionViewInfo(ByVal view As GridView)
+                view.DataController.EnsureFindRowByValueCache(view.DataController.Columns(descriptor.keyFieldName), view.RowCount)
+                view.BeginSelection()
+                Try
+                    view.ClearSelection()
+                    For i As Integer = 0 To SaveSelList.Count - 1
+                        SelectRowByRowInfo(view, CType(SaveSelList(i), RowInfo), i = SaveSelList.Count - 1)
+                    Next i
+                Finally
+                    view.EndSelection()
+                    view.DataController.DestroyFindRowByValueCache()
+                End Try
+            End Sub
 
-			Public Sub LoadExpansionViewInfo(ByVal view As GridView)
+            Public Sub LoadExpansionViewInfo(ByVal view As GridView)
 				If view.GroupedColumns.Count = 0 Then
 					Return
 				End If


### PR DESCRIPTION
Call the **EnsureFindRowByValueCache** method to create a row cache and **DestroyFindRowByValueCache** to destroy it in the **LoadSelectionViewInfo** method to increase the performance when restoring many selected rows.